### PR TITLE
PHP 5.0 syntax

### DIFF
--- a/admin/admin_tag.php
+++ b/admin/admin_tag.php
@@ -63,6 +63,7 @@ if ($tag_groups != 1) {
 if ( $tag_groups == 1 and isset($_POST['osm_tag_submit']) )
 {
 	// Override default value from the form
+	$tmp = preg_split("/_/",$_POST['language']);
 	$sync_options = array(
 		'overwrite' => isset($_POST['overwrite']),
 		'simulate' => isset($_POST['simulate']),
@@ -77,7 +78,7 @@ if ( $tag_groups == 1 and isset($_POST['osm_tag_submit']) )
 		'osm_tag_address_country' => isset($_POST['osm_tag_address_country']),
 		'osm_tag_address_postcode' => isset($_POST['osm_tag_address_postcode']),
 		'osm_tag_address_country_code' => isset($_POST['osm_tag_address_country_code']),
-		'language' => preg_split("/_/",$_POST['language'])[0]
+		'language' => $tmp[0],
 	);
 
 	// TODO allow to filter on overwrite
@@ -211,7 +212,7 @@ if ( $tag_groups == 1 and isset($_POST['osm_tag_submit']) )
 					//print_r($tag_ids);
 					if (!empty($tag_ids))
 					{
-						add_tags($tag_ids, [$image['id']]);
+						add_tags($tag_ids, array($image['id']));
 					}
 				}
 				$datas[] = $image['id'];


### PR DESCRIPTION
What I had earlier thought was Python-like code was actually PHP using syntax effective with version 5.4+.

Piwigo itself requires only PHP 5.0 or higher. So it looks like issue #107 is that the Piwigo server may be running a lower PHP version than 5.4. My host, for example, runs PHP 5.2; don't ask why. The unattractive syntax in this commit should work with any PHP 5.0+.